### PR TITLE
feat: unresolvedRef gets source and target results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        # Node 20 is EOL; kept here to satisfy the required status checks
-        node-version: [20, 22, 24, 26]
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ajv": "^8.20.0"
       },
       "engines": {
-        "node": ">=20.19 <22 || >=22.12"
+        "node": ">=22.12"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ajv": "^8.20.0"
       },
       "engines": {
-        "node": ">=22.12"
+        "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=20.19 <22 || >=22.12"
+    "node": ">=22.12"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "devDependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -83,16 +83,34 @@ export type ValidationError = {
   message: string
 }
 
-/** A reference that could not be resolved during parsing */
-export type UnresolvedReference = {
+/** Where a reference points, or where it was found */
+export type ReferenceEndpoint = {
+  /** The top-level collection, e.g. `resources`, `values`, `outputs` */
+  collection: string
+  /** The name of the item within that collection */
+  name: string
+  /** The path within that item, empty when the reference is to the item itself */
+  path: string
+}
+
+/** The location and content of a reference */
+export type ReferenceLocation = {
   /** The location where the reference was found */
   path: string
   /** The content of the reference (e.g. $.resources.project-1.id) */
   ref: string
 }
 
+/** A reference that could not be resolved during parsing */
+export type UnresolvedReference = ReferenceLocation & {
+  /** `ref` in split form: where the value will come from */
+  source: ReferenceEndpoint
+  /** `path` in split form: where the value belongs */
+  target: ReferenceEndpoint
+}
+
 /** A reference found during parsing */
-export type Reference = UnresolvedReference & {
+export type Reference = ReferenceLocation & {
   /** The object or array containing the reference */
   container: object | Array
   /** The key or index of the reference in the container */

--- a/src/refs.js
+++ b/src/refs.js
@@ -2,13 +2,22 @@ import is from './is.js'
 export default {find, resolve}
 
 /**
- * @param {import('.').Blueprint} validatedBlueprint
- * @param {import('.').ParserOptions} options
- * @returns {Array<import('.').Reference>}
+ * @typedef {import('.').Blueprint} Blueprint
+ * @typedef {import('.').ParserOptions} ParserOptions
+ * @typedef {import('.').Reference} Reference
+ * @typedef {import('.').UnresolvedReference} UnresolvedReference
+ * @typedef {import('.').ReferenceError} ReferenceError
+ * @typedef {import('.').ReferenceEndpoint} ReferenceEndpoint
+ */
+
+/**
+ * @param {Blueprint} validatedBlueprint
+ * @param {ParserOptions} options
+ * @returns {Array<Reference>}
  */
 function find(validatedBlueprint, options) {
   const {debug} = options
-  /** @type {Array<import('.').Reference>} */
+  /** @type {Array<Reference>} */
   const foundRefs = []
 
   /**
@@ -54,21 +63,21 @@ function find(validatedBlueprint, options) {
 }
 
 /**
- * @param {import('.').Blueprint} blueprint
- * @param {Array<import('.').Reference>} foundRefs
- * @param {import('.').ParserOptions} options
+ * @param {Blueprint} blueprint
+ * @param {Array<Reference>} foundRefs
+ * @param {ParserOptions} options
  * @returns {{
- *   resolvedBlueprint: import('.').Blueprint
- *   unresolvedRefs: Array<import('.').UnresolvedReference> | undefined
- *   refErrors: Array<import('.').ReferenceError>
+ *   resolvedBlueprint: Blueprint
+ *   unresolvedRefs: Array<UnresolvedReference> | undefined
+ *   refErrors: Array<ReferenceError>
  * }}
  */
 function resolve(blueprint, foundRefs, options) {
   const {parameters = {}, invalidReferenceTypes} = options
 
-  /** @type {Record<string, import('.').Reference>} */
+  /** @type {Record<string, Reference>} */
   const refs = {}
-  /** @type {Array<import('.').UnresolvedReference>} */
+  /** @type {Array<UnresolvedReference>} */
   const unresolvedRefs = []
   const refErrors = []
   for (const foundRef of foundRefs) {
@@ -154,14 +163,14 @@ function resolve(blueprint, foundRefs, options) {
 
 /**
  * Create an unresolved reference from a found reference.
- * @param {import('.').Reference} foundRef
- * @returns {import('.').UnresolvedReference}
+ * @param {Reference} foundRef
+ * @returns {UnresolvedReference}
  */
 function unresolvedReference(foundRef) {
   return {
     path: foundRef.path,
     ref: foundRef.ref,
-    source: endpoint(foundRef.ref.startsWith('$.') ? foundRef.ref.slice(2) : foundRef.ref),
+    source: endpoint(foundRef.ref.slice(2)),
     target: endpoint(foundRef.path),
   }
 }
@@ -169,7 +178,7 @@ function unresolvedReference(foundRef) {
 /**
  * Create a reference endpoint from a location string.
  * @param {string} location
- * @returns {import('.').ReferenceEndpoint}
+ * @returns {ReferenceEndpoint}
  */
 function endpoint(location) {
   const [collection, name, ...path] = location.split('.')

--- a/src/refs.js
+++ b/src/refs.js
@@ -81,7 +81,7 @@ function resolve(blueprint, foundRefs, options) {
     if (refs[ref]) {
       if (refType === 'resources') {
         // all resources references must be resolved during deployment
-        unresolvedRefs.push({path: foundRef.path, ref: foundRef.ref})
+        unresolvedRefs.push(unresolvedReference(foundRef))
       } else {
         foundRef.container[foundRef.property] = refs[ref].container[refs[ref].property]
       }
@@ -129,7 +129,7 @@ function resolve(blueprint, foundRefs, options) {
           })
         } else {
           // all resources references must be resolved during deployment
-          unresolvedRefs.push({path: foundRef.path, ref: foundRef.ref})
+          unresolvedRefs.push(unresolvedReference(foundRef))
         }
       } else {
         refErrors.push({
@@ -150,4 +150,29 @@ function resolve(blueprint, foundRefs, options) {
     unresolvedRefs: unresolvedRefs.length ? unresolvedRefs : undefined,
     refErrors,
   }
+}
+
+/**
+ * Create an unresolved reference from a found reference.
+ * @param {import('.').Reference} foundRef
+ * @returns {import('.').UnresolvedReference}
+ */
+function unresolvedReference(foundRef) {
+  return {
+    path: foundRef.path,
+    ref: foundRef.ref,
+    source: endpoint(foundRef.ref.startsWith('$.') ? foundRef.ref.slice(2) : foundRef.ref),
+    target: endpoint(foundRef.path),
+  }
+}
+
+/**
+ * Create a reference endpoint from a location string.
+ * @param {string} location
+ * @returns {import('.').ReferenceEndpoint}
+ */
+function endpoint(location) {
+  const [collection, name, ...path] = location.split('.')
+
+  return {collection, name: name ?? '', path: path.join('.')}
 }

--- a/test/mocks/reference-errors.js
+++ b/test/mocks/reference-errors.js
@@ -235,6 +235,8 @@ export default {
       {
         path: 'resources.another-function.config.disk',
         ref: '$.resources.a-function.config.disk',
+        source: {collection: 'resources', name: 'a-function', path: 'config.disk'},
+        target: {collection: 'resources', name: 'another-function', path: 'config.disk'},
       },
     ],
     error: {

--- a/test/mocks/reference-errors.js
+++ b/test/mocks/reference-errors.js
@@ -244,4 +244,44 @@ export default {
       message: "Reference error '$.parameters.memory': 'memory' not found in passed parameters",
     },
   },
+
+  // collection-only reference has no name to resolve
+  repeatedCollectionOnlyReference: {
+    input: {
+      resources: [
+        {
+          name: 'a-function',
+          type: 'cloud-function',
+          config: {
+            first: '$.resources',
+            second: '$.resources',
+          },
+        },
+      ],
+    },
+    expected: {
+      resources: [
+        {
+          name: 'a-function',
+          type: 'cloud-function',
+          config: {
+            first: '$.resources',
+            second: '$.resources',
+          },
+        },
+      ],
+    },
+    unresolved: [
+      {
+        path: 'resources.a-function.config.second',
+        ref: '$.resources',
+        source: {collection: 'resources', name: '', path: ''},
+        target: {collection: 'resources', name: 'a-function', path: 'config.second'},
+      },
+    ],
+    error: {
+      type: 'missing_resource',
+      message: "Reference error '$.resources': 'undefined' not found in blueprint resources",
+    },
+  },
 }

--- a/test/mocks/references.js
+++ b/test/mocks/references.js
@@ -141,6 +141,8 @@ export default {
       {
         path: 'resources.a-function.config.memory',
         ref: '$.resources.another-function.config.env.memory',
+        source: {collection: 'resources', name: 'another-function', path: 'config.env.memory'},
+        target: {collection: 'resources', name: 'a-function', path: 'config.memory'},
       },
     ],
   },
@@ -178,6 +180,8 @@ export default {
       {
         path: 'resources.a-function.projects[1]',
         ref: '$.resources.a-project.name',
+        source: {collection: 'resources', name: 'a-project', path: 'name'},
+        target: {collection: 'resources', name: 'a-function', path: 'projects[1]'},
       },
     ],
   },
@@ -228,6 +232,12 @@ export default {
       {
         path: 'resources.a-function.config.settings[0].projects[2]',
         ref: '$.resources.a-project.name',
+        source: {collection: 'resources', name: 'a-project', path: 'name'},
+        target: {
+          collection: 'resources',
+          name: 'a-function',
+          path: 'config.settings[0].projects[2]',
+        },
       },
     ],
   },
@@ -358,14 +368,20 @@ export default {
       {
         path: 'resources.another-function.config.memory',
         ref: '$.resources.a-function.config.memory',
+        source: {collection: 'resources', name: 'a-function', path: 'config.memory'},
+        target: {collection: 'resources', name: 'another-function', path: 'config.memory'},
       },
       {
         path: 'outputs.configured-memory-1.value',
         ref: '$.resources.another-function.config.memory',
+        source: {collection: 'resources', name: 'another-function', path: 'config.memory'},
+        target: {collection: 'outputs', name: 'configured-memory-1', path: 'value'},
       },
       {
         path: 'outputs.configured-memory-2.value',
         ref: '$.resources.another-function.config.memory',
+        source: {collection: 'resources', name: 'another-function', path: 'config.memory'},
+        target: {collection: 'outputs', name: 'configured-memory-2', path: 'value'},
       },
     ],
   },
@@ -403,6 +419,8 @@ export default {
       {
         path: 'resources.a-function.projects[2]',
         ref: '$.resources.a-project.name',
+        source: {collection: 'resources', name: 'a-project', path: 'name'},
+        target: {collection: 'resources', name: 'a-function', path: 'projects[2]'},
       },
     ],
   },
@@ -452,6 +470,51 @@ export default {
       {
         path: 'resources.a-function.config.settings[0].projects[0]',
         ref: '$.resources.a-project.name',
+        source: {collection: 'resources', name: 'a-project', path: 'name'},
+        target: {
+          collection: 'resources',
+          name: 'a-function',
+          path: 'config.settings[0].projects[0]',
+        },
+      },
+    ],
+  },
+
+  unresolvedRootReference: {
+    input: {
+      resources: [
+        {
+          name: 'a-project',
+          type: 'cloud-project',
+        },
+        {
+          name: 'a-function',
+          type: 'cloud-function',
+          project: '$.resources.a-project',
+        },
+      ],
+    },
+
+    expected: {
+      resources: [
+        {
+          name: 'a-project',
+          type: 'cloud-project',
+        },
+        {
+          name: 'a-function',
+          type: 'cloud-function',
+          project: '$.resources.a-project',
+        },
+      ],
+    },
+
+    unresolved: [
+      {
+        path: 'resources.a-function.project',
+        ref: '$.resources.a-project',
+        source: {collection: 'resources', name: 'a-project', path: ''},
+        target: {collection: 'resources', name: 'a-function', path: 'project'},
       },
     ],
   },


### PR DESCRIPTION
`UnresolvedReference` gets `source` and `target` objects. A convenience so consumers don't have to parse them again. entirely additive.

```js
{
  path: 'resources.another-function.config.disk',
  ref: '$.resources.a-function.config.disk',
  source: {collection: 'resources', name: 'a-function', path: 'config.disk'},
  target: {collection: 'resources', name: 'another-function', path: 'config.disk'},
}
```

added mock `repeatedCollectionOnlyReference` to ensure coverage is 100% even though it's an unlikely use case.

also remove Node 20 from matrix; I wasn't able to in the last PR but ruleset has since been adjusted.
